### PR TITLE
feat: use vim.schedule for storing history

### DIFF
--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -226,7 +226,9 @@ function yanky.on_yank()
   local entry = utils.get_register_info(vim.v.event.regname)
   entry.filetype = vim.bo.filetype
 
-  yanky.history.push(entry)
+  vim.schedule(function()
+    yanky.history.push(entry)
+  end)
 
   preserve_cursor.on_yank()
 end


### PR DESCRIPTION
Using `vim.schedule` to store history makes sure storing history doesn't block yanking