### PR TITLE
Load telescope mappings on demand

### DIFF
--- a/lua/yanky/telescope/yank_history.lua
+++ b/lua/yanky/telescope/yank_history.lua
@@ -5,7 +5,7 @@ local actions = require("telescope.actions")
 local entry_display = require("telescope.pickers.entry_display")
 local conf = require("telescope.config").values
 local mapping = require("yanky.telescope.mapping")
-local config = require("yanky.config").options.picker.telescope
+local config = require("yanky.config")
 
 local yank_history = {}
 
@@ -46,7 +46,7 @@ function yank_history.previewer()
 end
 
 function yank_history.attach_mappings(_, map)
-  local mappings = config.mappings or mapping.get_defaults()
+  local mappings = config.options.picker.telescope.mappings or mapping.get_defaults()
 
   if mappings.default then
     actions.select_default:replace(mappings.default)


### PR DESCRIPTION
I am calling `require'yanky.config'.setup` twice to set mappings for telescope. This patch is needed to load the latest mappings for the picker.

The reason why this is needed is because I am using lazy-loading feature by packer.nvim for both yanky & telescope.
```lua
-- minimal setup for packer.nvim
{
  "gbprod/yanky.nvim",
  keys = {
    { "n", "<Plug>(YankyPutAfter)" },
  },
  setup = function()
    vim.keymap.set('n', 'p', '<Plug>(YankyPutAfter)')
  end,
  config = function()
    require("yanky").setup {}
  end
},

{
  "nvim-telescope/telescope.nvim",
  cmd = { "Telescope" },
  wants = { "yanky.nvim" },
  config = function()
    require("telescope").load_extension "yank_history"

    local utils = require "yanky.utils"
    local mapping = require "yanky.telescope.mapping"
    local options = require("yanky.config").options
    options.picker.telescope.mappings = {
      default = mapping.put "p",
      n = {
        p = mapping.put "p",
        P = mapping.put "P",
        d = mapping.delete(),
        r = mapping.set_register(utils.get_default_register()),
      },
    }
    require("yanky.config").setup(options)
  end,
},
```

When I push `p` soon after launching Neovim, it loads yanky only with calling `setup{}`. In this case, I don't want to load telescope because it takes a bit seconds.

On the other hand, when I call `:Telescope yank_history` soon after launching Neovim, it loads yanky and telescope. Here I call `require'yanky.config'.setup` after loading telescope. Not in loading yanky because it have not loaded telescope yet.
