### PR TITLE
replace preserve_cursor_position.enable with preserve_cursor_position…

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ require("yanky").setup({
 })
 ```
 
-#### `preserve_cursor_position.enable`
+#### `preserve_cursor_position.enabled`
 
 Default : `true`
 

--- a/doc/yanky.txt
+++ b/doc/yanky.txt
@@ -443,9 +443,9 @@ a yank.
 <
 
 
-                                     *yanky-`preserve_cursor_position.enable`*
+                                     *yanky-`preserve_cursor_position.enabled`*
 
-`preserve_cursor_position.enable`      Default : `true`
+`preserve_cursor_position.enabled`      Default : `true`
 
 
 Define if cursor position should be preserved on yank. This works only if


### PR DESCRIPTION
….enabled in documentation

Hi, cool plugin!
Tried it yesterday, first impression is good.
I hope this will fix all the bugs of yoink that have been haunting me for years.

Anyway, I noticed that the documentation text and the documentation code examples disagree on the naming of this field.
I guess, the code is authoritative here, so I adapted the documentation accordingly.