### PR TITLE
switch gputbefore and gputafter

### DIFF
--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -258,8 +258,8 @@ function yanky.register_plugs()
   for type, type_text in pairs({
     p = "PutAfter",
     P = "PutBefore",
-    gp = "GPutBefore",
-    gP = "GPutAfter",
+    gp = "GPutAfter",
+    gP = "GPutBefore",
     ["]p"] = "PutIndentAfter",
     ["[p"] = "PutIndentBefore",
   }) do


### PR DESCRIPTION
Hi,
I noticed today that `YankyGPutBefore` and `YankyGPutAfter` are mixed up. Probably not so many people are actually using this feature :)

On a side note: the difference between `YankyPutBefore` and `YankyGPutBefore` (and likewise for `...After`) seems relevant only for linewise yanks, as is vanilla vim behaviour. What do you think about extending this to characterwise yanks? In other words, I would suggest adding a configuration option, so `YankyPutAfter` with a characterwise selection puts the cursor at the beginning of the pasted text. It should probably be an opt-in configuration option, because it overrides vanilla vim behaviour.