### PR TITLE
Allows selection of any existing highlight group for highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Yanky comes with the following defaults:
   highlight = {
     on_put = true,
     on_yank = true,
+    put_higroup = "YankyPut",
+    yank_higroup = "YankyYanked",
     timer = 500,
   },
   preserve_cursor_position = {
@@ -349,12 +351,14 @@ require("yanky").setup({
   highlight = {
     on_put = true,
     on_yank = true,
+    put_higroup = "YankyPut",
+    yank_higroup = "YankyYanked",
     timer = 500,
   },
 })
 ```
 
-You can override `YankyPut` highlight to change colors.
+You can change `yank_higroup` or `put_higroup` to any of the existing highlight-groups to change the highlight color.
 
 #### `highlight.on_put`
 
@@ -367,6 +371,18 @@ Define if highlight put text feature is enabled.
 Default : `true`
 
 Define if highlight yanked text feature is enabled.
+
+#### `highlight.put_higroup`
+
+Default : `true`
+
+The highlight group to be used for highlighting on put.
+
+#### `highlight.yank_higroup`
+
+Default : `true`
+
+The highlight group to be used for highlighting on yank.
 
 #### `highlight.timer`
 
@@ -412,6 +428,8 @@ has been defined.
 | ------------------------------- | ----------- | -------------- |
 | Highlight color for put text    | YankyPut    | link to Search |
 | Highlight color for yanked text | YankyYanked | link to Search |
+
+Or the name of any of the existing vim highlight-groups.
 
 ## 🤝 Integrations
 

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -16,6 +16,7 @@ local default_values = {
     on_put = true,
     on_yank = true,
     timer = 500,
+	higroup = "YankyYanked",
   },
   preserve_cursor_position = {
     enabled = true,

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -16,7 +16,8 @@ local default_values = {
     on_put = true,
     on_yank = true,
     timer = 500,
-	higroup = "YankyYanked",
+    yank_higroup = "YankyYanked",
+    put_higroup = "YankyPut",
   },
   preserve_cursor_position = {
     enabled = true,

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -15,9 +15,9 @@ local default_values = {
   highlight = {
     on_put = true,
     on_yank = true,
-    timer = 500,
-    yank_higroup = "YankyYanked",
     put_higroup = "YankyPut",
+    yank_higroup = "YankyYanked",
+    timer = 500,
   },
   preserve_cursor_position = {
     enabled = true,

--- a/lua/yanky/highlight.lua
+++ b/lua/yanky/highlight.lua
@@ -1,63 +1,65 @@
 local highlight = {}
 
 function highlight.setup()
-  highlight.config = require("yanky.config").options.highlight
-  if highlight.config.on_put then
-    highlight.hl_put = vim.api.nvim_create_namespace("yanky.put")
-    highlight.timer = vim.loop.new_timer()
+	highlight.config = require("yanky.config").options.highlight
+	if highlight.config.on_put then
+		highlight.hl_put = vim.api.nvim_create_namespace("yanky.put")
+		highlight.timer = vim.loop.new_timer()
 
-    vim.api.nvim_set_hl(0, "YankyPut", { link = "Search", default = true })
-    vim.api.nvim_set_hl(0, "YankyYanked", { link = "Search", default = true })
-  end
+		vim.api.nvim_set_hl(0, "YankyPut", { link = "Search", default = true })
+		vim.api.nvim_set_hl(0, "YankyYanked", { link = "Search", default = true })
+	end
 
-  if highlight.config.on_yank then
-    vim.api.nvim_create_autocmd("TextYankPost", {
-      pattern = "*",
-      callback = function(_)
-        vim.highlight.on_yank({ higroup = "YankyYanked", timeout = highlight.config.timer })
-      end,
-    })
-  end
+	if highlight.config.on_yank then
+		local aesthetics = vim.api.nvim_create_augroup("aesthetic_settings", { clear = true })
+		vim.api.nvim_create_autocmd("TextYankPost", {
+			pattern = "*",
+			group = aesthetics,
+			callback = function(_)
+				vim.highlight.on_yank({ higroup = "Visual", timeout = highlight.config.timer })
+			end,
+		})
+	end
 end
 
 local function get_region()
-  local start = vim.api.nvim_buf_get_mark(0, "[")
-  local finish = vim.api.nvim_buf_get_mark(0, "]")
+	local start = vim.api.nvim_buf_get_mark(0, "[")
+	local finish = vim.api.nvim_buf_get_mark(0, "]")
 
-  return {
-    start_row = start[1] - 1,
-    start_col = start[2],
-    end_row = finish[1] - 1,
-    end_col = finish[2],
-  }
+	return {
+		start_row = start[1] - 1,
+		start_col = start[2],
+		end_row = finish[1] - 1,
+		end_col = finish[2],
+	}
 end
 
 function highlight.highlight_put(state)
-  if not highlight.config.on_put then
-    return
-  end
+	if not highlight.config.on_put then
+		return
+	end
 
-  highlight.timer:stop()
-  vim.api.nvim_buf_clear_namespace(0, highlight.hl_put, 0, -1)
+	highlight.timer:stop()
+	vim.api.nvim_buf_clear_namespace(0, highlight.hl_put, 0, -1)
 
-  local region = get_region()
+	local region = get_region()
 
-  vim.highlight.range(
-    0,
-    highlight.hl_put,
-    "YankyPut",
-    { region.start_row, region.start_col },
-    { region.end_row, region.end_col },
-    { regtype = vim.fn.getregtype(state.register), inclusive = true }
-  )
+	vim.highlight.range(
+		0,
+		highlight.hl_put,
+		"YankyPut",
+		{ region.start_row, region.start_col },
+		{ region.end_row, region.end_col },
+		{ regtype = vim.fn.getregtype(state.register), inclusive = true }
+	)
 
-  highlight.timer:start(
-    highlight.config.timer,
-    0,
-    vim.schedule_wrap(function()
-      vim.api.nvim_buf_clear_namespace(0, highlight.hl_put, 0, -1)
-    end)
-  )
+	highlight.timer:start(
+		highlight.config.timer,
+		0,
+		vim.schedule_wrap(function()
+			vim.api.nvim_buf_clear_namespace(0, highlight.hl_put, 0, -1)
+		end)
+	)
 end
 
 return highlight

--- a/lua/yanky/highlight.lua
+++ b/lua/yanky/highlight.lua
@@ -10,16 +10,13 @@ function highlight.setup()
 		vim.api.nvim_set_hl(0, "YankyYanked", { link = "Search", default = true })
 	end
 
+
 	if highlight.config.on_yank then
-		local aesthetics = vim.api.nvim_create_augroup("aesthetic_settings", { clear = true })
 		vim.api.nvim_create_autocmd("TextYankPost", {
 			pattern = "*",
-			group = aesthetics,
-			command = "silent! lua vim.highlight.on_yank({higroup = \"Visual\", timeout = 200})",
-		--	callback = function(_)
-
-		--		vim.highlight.on_yank({ higroup = "Visual", timeout = highlight.config.timer })
-		--	end,
+			callback = function(_)
+				vim.highlight.on_yank({ higroup = highlight.config.higroup, timeout = highlight.config.timer })
+			end,
 		})
 	end
 end

--- a/lua/yanky/highlight.lua
+++ b/lua/yanky/highlight.lua
@@ -1,64 +1,64 @@
 local highlight = {}
 
 function highlight.setup()
-	highlight.config = require("yanky.config").options.highlight
-	if highlight.config.on_put then
-		highlight.hl_put = vim.api.nvim_create_namespace("yanky.put")
-		highlight.timer = vim.loop.new_timer()
+  highlight.config = require("yanky.config").options.highlight
+  if highlight.config.on_put then
+    highlight.hl_put = vim.api.nvim_create_namespace("yanky.put")
+    highlight.timer = vim.loop.new_timer()
 
-		vim.api.nvim_set_hl(0, "YankyPut", { link = "Search", default = true })
-		vim.api.nvim_set_hl(0, "YankyYanked", { link = "Search", default = true })
-	end
+    vim.api.nvim_set_hl(0, "YankyPut", { link = "Search", default = true })
+    vim.api.nvim_set_hl(0, "YankyYanked", { link = "Search", default = true })
+  end
 
 
-	if highlight.config.on_yank then
-		vim.api.nvim_create_autocmd("TextYankPost", {
-			pattern = "*",
-			callback = function(_)
-				vim.highlight.on_yank({ higroup = highlight.config.yank_higroup, timeout = highlight.config.timer })
-			end,
-		})
-	end
+  if highlight.config.on_yank then
+    vim.api.nvim_create_autocmd("TextYankPost", {
+      pattern = "*",
+      callback = function(_)
+        vim.highlight.on_yank({ higroup = highlight.config.yank_higroup, timeout = highlight.config.timer })
+      end,
+    })
+  end
 end
 
 local function get_region()
-	local start = vim.api.nvim_buf_get_mark(0, "[")
-	local finish = vim.api.nvim_buf_get_mark(0, "]")
+  local start = vim.api.nvim_buf_get_mark(0, "[")
+  local finish = vim.api.nvim_buf_get_mark(0, "]")
 
-	return {
-		start_row = start[1] - 1,
-		start_col = start[2],
-		end_row = finish[1] - 1,
-		end_col = finish[2],
-	}
+  return {
+    start_row = start[1] - 1,
+    start_col = start[2],
+    end_row = finish[1] - 1,
+    end_col = finish[2],
+  }
 end
 
 function highlight.highlight_put(state)
-	if not highlight.config.on_put then
-		return
-	end
+  if not highlight.config.on_put then
+    return
+  end
 
-	highlight.timer:stop()
-	vim.api.nvim_buf_clear_namespace(0, highlight.hl_put, 0, -1)
+  highlight.timer:stop()
+  vim.api.nvim_buf_clear_namespace(0, highlight.hl_put, 0, -1)
 
-	local region = get_region()
+  local region = get_region()
 
-	vim.highlight.range(
-		0,
-		highlight.hl_put,
-		highlight.config.put_higroup,
-		{ region.start_row, region.start_col },
-		{ region.end_row, region.end_col },
-		{ regtype = vim.fn.getregtype(state.register), inclusive = true }
-	)
+  vim.highlight.range(
+    0,
+    highlight.hl_put,
+    highlight.config.put_higroup,
+    { region.start_row, region.start_col },
+    { region.end_row, region.end_col },
+    { regtype = vim.fn.getregtype(state.register), inclusive = true }
+  )
 
-	highlight.timer:start(
-		highlight.config.timer,
-		0,
-		vim.schedule_wrap(function()
-			vim.api.nvim_buf_clear_namespace(0, highlight.hl_put, 0, -1)
-		end)
-	)
+  highlight.timer:start(
+    highlight.config.timer,
+    0,
+    vim.schedule_wrap(function()
+      vim.api.nvim_buf_clear_namespace(0, highlight.hl_put, 0, -1)
+    end)
+  )
 end
 
 return highlight

--- a/lua/yanky/highlight.lua
+++ b/lua/yanky/highlight.lua
@@ -15,9 +15,11 @@ function highlight.setup()
 		vim.api.nvim_create_autocmd("TextYankPost", {
 			pattern = "*",
 			group = aesthetics,
-			callback = function(_)
-				vim.highlight.on_yank({ higroup = "Visual", timeout = highlight.config.timer })
-			end,
+			command = "silent! lua vim.highlight.on_yank({higroup = \"Visual\", timeout = 200})",
+		--	callback = function(_)
+
+		--		vim.highlight.on_yank({ higroup = "Visual", timeout = highlight.config.timer })
+		--	end,
 		})
 	end
 end

--- a/lua/yanky/highlight.lua
+++ b/lua/yanky/highlight.lua
@@ -10,7 +10,6 @@ function highlight.setup()
     vim.api.nvim_set_hl(0, "YankyYanked", { link = "Search", default = true })
   end
 
-
   if highlight.config.on_yank then
     vim.api.nvim_create_autocmd("TextYankPost", {
       pattern = "*",

--- a/lua/yanky/highlight.lua
+++ b/lua/yanky/highlight.lua
@@ -15,7 +15,7 @@ function highlight.setup()
 		vim.api.nvim_create_autocmd("TextYankPost", {
 			pattern = "*",
 			callback = function(_)
-				vim.highlight.on_yank({ higroup = highlight.config.higroup, timeout = highlight.config.timer })
+				vim.highlight.on_yank({ higroup = highlight.config.yank_higroup, timeout = highlight.config.timer })
 			end,
 		})
 	end
@@ -46,7 +46,7 @@ function highlight.highlight_put(state)
 	vim.highlight.range(
 		0,
 		highlight.hl_put,
-		"YankyPut",
+		highlight.config.put_higroup,
 		{ region.start_row, region.start_col },
 		{ region.end_row, region.end_col },
 		{ regtype = vim.fn.getregtype(state.register), inclusive = true }


### PR DESCRIPTION
Added code to let the user select any highlight group for use with highlight on yank/put.


Added documentation to `README.md` but not to the actual documentation text file because my understanding is that changes to the readme are automatically incorporated into the help documentation when committed to main.