### PR TITLE
fix!: replace telescope mappings instead of merging

### DIFF
--- a/lua/yanky/telescope/yank_history.lua
+++ b/lua/yanky/telescope/yank_history.lua
@@ -46,17 +46,14 @@ function yank_history.previewer()
 end
 
 function yank_history.attach_mappings(_, map)
-  local mappings = vim.tbl_deep_extend("force", mapping.get_defaults(), config.options.picker.telescope.mappings or {})
+  local defaults_mappings = mapping.get_defaults()
 
-  if mappings.default then
-    actions.select_default:replace(mappings.default)
-  end
+  actions.select_default:replace(config.options.picker.telescope.mappings.default or defaults_mappings.default)
 
   for _, mode in pairs({ "i", "n" }) do
-    if mappings[mode] then
-      for keys, action in pairs(mappings[mode]) do
-        map(mode, keys, action)
-      end
+    local mappings = config.options.picker.telescope.mappings[mode] or defaults_mappings[mode]
+    for keys, action in pairs(mappings) do
+      map(mode, keys, action)
     end
   end
 


### PR DESCRIPTION
Partial revert of https://github.com/gbprod/yanky.nvim/commit/c4c794afd762a00ca543972e5b9e34ce9aa14a87

Overriding telescope mappings will only replace mappings in a mode.