### PR TITLE
Revert "fix!: replace telescope mappings instead of merging (#106)"

### DIFF
--- a/lua/yanky/telescope/yank_history.lua
+++ b/lua/yanky/telescope/yank_history.lua
@@ -46,14 +46,17 @@ function yank_history.previewer()
 end
 
 function yank_history.attach_mappings(_, map)
-  local defaults_mappings = mapping.get_defaults()
+  local mappings = vim.tbl_deep_extend("force", mapping.get_defaults(), config.options.picker.telescope.mappings or {})
 
-  actions.select_default:replace(config.options.picker.telescope.mappings.default or defaults_mappings.default)
+  if mappings.default then
+    actions.select_default:replace(mappings.default)
+  end
 
   for _, mode in pairs({ "i", "n" }) do
-    local mappings = config.options.picker.telescope.mappings[mode] or defaults_mappings[mode]
-    for keys, action in pairs(mappings) do
-      map(mode, keys, action)
+    if mappings[mode] then
+      for keys, action in pairs(mappings[mode]) do
+        map(mode, keys, action)
+      end
     end
   end
 


### PR DESCRIPTION
This reverts commit 406d6199b231cfa4a5c51a122ff017fd93be24bb.