### PR TITLE
fix!: change yanky's telescope default mapping to avoid collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ require("yanky").setup({
       mappings = {
         default = mapping.put("p"),
         i = {
-          ["<c-p>"] = mapping.put("p"),
+          ["<c-g>"] = mapping.put("p"),
           ["<c-k>"] = mapping.put("P"),
           ["<c-x>"] = mapping.delete(),
           ["<c-r>"] = mapping.set_register(utils.get_default_register()),

--- a/lua/yanky/telescope/mapping.lua
+++ b/lua/yanky/telescope/mapping.lua
@@ -59,7 +59,7 @@ function mapping.get_defaults()
   return {
     default = mapping.put("p"),
     i = {
-      ["<c-p>"] = mapping.put("p"),
+      ["<c-g>"] = mapping.put("p"),
       ["<c-k>"] = mapping.put("P"),
       ["<c-x>"] = mapping.delete(),
       ["<c-r>"] = mapping.set_register(utils.get_default_register()),


### PR DESCRIPTION
Telescope default mapping use `<c-p>` to go to previous item, it's override by yanky's default mapping and I think it's not a good idea. I've changed this default mapping with `<c-g>` as it's not used by telescope.

Ref: #134