### PR TITLE
fix(textobject): check for nil and add setting to enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Yanky comes with the following defaults:
   preserve_cursor_position = {
     enabled = true,
   },
+  textobject = {
+   enabled = false,
+  },
 }
 ```
 
@@ -658,10 +661,22 @@ To go further, Plug mappings are constructed like this: `Yanky(put-type)(modifie
 
 ## Text object
 
-_This is experimental, please, report any issue._
+_This is experimental, please, report any issues._
 
 Yanky comes with a text object corresponding to last put text. To use it, you
-have to set a keymap:
+have to enable it in settings and set a keymap.
+
+### ⚙️ Configuration
+
+```lua
+require("yanky").setup({
+  textobj = {
+    enabled = true,
+  },
+})
+```
+
+### ⌨️ Mappings
 
 ```lua
 vim.keymap.set({ "o", "x" }, "lp", function()

--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -165,7 +165,9 @@ function yanky.init_ring(type, register, count, is_visual, callback)
   yanky.ring.is_cycling = false
 
   yanky.attach_cancel()
-  textobj.save_put()
+  if yanky.config.options.textobject.enabled then
+    textobj.save_put()
+  end
 end
 
 function yanky.can_cycle()

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -31,6 +31,9 @@ local default_values = {
       mappings = nil,
     },
   },
+  textobject = {
+    enabled = false,
+  },
 }
 
 function config.setup(options)

--- a/lua/yanky/textobj.lua
+++ b/lua/yanky/textobj.lua
@@ -35,7 +35,7 @@ function textobj.save_put()
   }
   vim.api.nvim_buf_attach(0, false, {
     on_lines = function(_, _, _, first_line)
-      if first_line <= vim.b.yanky_textobj.region.end_row then
+      if vim.b.yanky_textobj and (first_line <= vim.b.yanky_textobj.region.end_row) then
         vim.b.yanky_textobj = nil
         return true
       end


### PR DESCRIPTION
Fixes #144

In addition, I'm adding a new setting for enabling the text object, to avoid unnecessarily tracking buffer changes when the feature is disabled. 

Since it is still experimental, I think it should be off by default.