### PR TITLE
fix(textobj): consistent naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Yanky comes with the following defaults:
   preserve_cursor_position = {
     enabled = true,
   },
-  textobject = {
+  textobj = {
    enabled = false,
   },
 }

--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -165,7 +165,7 @@ function yanky.init_ring(type, register, count, is_visual, callback)
   yanky.ring.is_cycling = false
 
   yanky.attach_cancel()
-  if yanky.config.options.textobject.enabled then
+  if yanky.config.options.textobj.enabled then
     textobj.save_put()
   end
 end

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -31,7 +31,7 @@ local default_values = {
       mappings = nil,
     },
   },
-  textobject = {
+  textobj = {
     enabled = false,
   },
 }


### PR DESCRIPTION
Followup of #145. The docs used `textobj` instead of the setting `textobject`, causing some confusion (see #146). This PR changes the setting to `textobj` everywhere for consistency with the name of the respective module.