### PR TITLE
feat(ring): allows to update register content on cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Yanky comes with the following defaults:
     storage_path = vim.fn.stdpath("data") .. "/databases/yanky.db", -- Only for sqlite storage
     sync_with_numbered_registers = true,
     cancel_event = "update",
+    ignore_registers = { "_" },
+    update_register_on_cycle = false, -- EXPERIMENTAL
   },
   picker = {
     select = {
@@ -141,6 +143,7 @@ require("yanky").setup({
     sync_with_numbered_registers = true,
     cancel_event = "update",
     ignore_registers = { "_" },
+    update_register_on_cycle = false,
   },
   system_clipboard = {
     sync_with_ring = true,
@@ -222,6 +225,16 @@ added to your yank ring.
 If `&clipboard` is empty, if you yank something outside of Neovim, this will be
 the first value you'll have when cycling through the ring. Basicly, you can do
 `p` and then `<c-p>` to paste yanked text.
+
+### `ring.update_register_on_cycle`
+
+**EXPERIMENTAL**
+
+Default: `false`
+
+Using the `update_register_on_cycle` option, when you cycle through the ring,
+the contents of the register used to update will be updated with the last
+content cycled.
 
 ### Commands
 

--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -195,7 +195,7 @@ function yanky.cycle(direction)
 
     local reg = utils.get_register_info(yanky.ring.state.register)
     local first = yanky.history.first()
-    if reg.regcontents == first.regcontents and reg.regtype == first.regtype then
+    if nil ~= first and reg.regcontents == first.regcontents and reg.regtype == first.regtype then
       yanky.history.skip()
     end
   end
@@ -241,6 +241,10 @@ function yanky.cycle(direction)
       yanky.ring.callback(new_state, do_put)
     end
   end)
+
+  if yanky.config.options.ring.update_register_on_cycle then
+    vim.fn.setreg(new_state.register, next_content.regcontents, next_content.regtype)
+  end
 
   yanky.ring.is_cycling = true
   yanky.ring.state = new_state

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -10,6 +10,7 @@ local default_values = {
     sync_with_numbered_registers = true,
     ignore_registers = { "_" },
     cancel_event = "update",
+    update_register_on_cycle = false,
   },
   system_clipboard = {
     sync_with_ring = true,


### PR DESCRIPTION
Using the `update_register_on_cycle` option, when you cycle through the ring, the contents of the register used to update will be updated with the last content cycled.

Ref: #76