### PR TITLE
docs: mention `cmp_yanky`

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ to customize this) or the awesome [telescope.nvim](https://github.com/nvim-teles
 It uses the same history as yank ring, so, if you want to increase history size,
 just use [`ring.history_length` option](#ringhistory_length).
 
+### Yank history completions
+
+Using [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [cmp_yanky](https://github.com/chrisgrieser/cmp_yanky), you can also get suggestions from your yank history as you type in insert mode.
+
 ### ⚙️ Configuration
 
 To use `vim.ui.select` picker, just call `YankyRingHistory` command.


### PR DESCRIPTION
Hi, I have created a simple cmp-source for the yanky's history. Basically, this gives you suggestions from your clipboard history: https://github.com/chrisgrieser/cmp_yanky

I thought it might be worth mentioning in the README that such an integration exists :)

