### PR TITLE
feat: Add timer option to preserve cursor position functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Yanky comes with the following defaults:
   },
   preserve_cursor_position = {
     enabled = true,
+    timer = 0
   },
   textobj = {
    enabled = true,
@@ -481,7 +482,11 @@ text. Could be annoying especially when yanking a large text object such as a
 paragraph or a large text object.
 
 With this feature, yank will function exactly the same as previously with the one
-difference being that the cursor position will not change after performing a yank.
+difference being that the cursor position will be restored after performing a yank.
+
+To prevent a possible jarring jump, an optional delay can be configured, with the
+default set to 0, which in many cases gives the appearance of preventing the
+cursor from moving at all.
 
 ### ⌨️ Mappings
 

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -22,6 +22,7 @@ local default_values = {
   },
   preserve_cursor_position = {
     enabled = true,
+    timer = 0,
   },
   picker = {
     select = {

--- a/lua/yanky/preserve_cursor.lua
+++ b/lua/yanky/preserve_cursor.lua
@@ -15,13 +15,15 @@ function preserve_cursor.on_yank()
   end
 
   if nil ~= preserve_cursor.state.cusor_position then
-    vim.fn.setpos(".", preserve_cursor.state.cusor_position)
-    vim.fn.winrestview(preserve_cursor.state.win_state)
+    vim.defer_fn(function()
+      vim.fn.setpos(".", preserve_cursor.state.cusor_position)
+      vim.fn.winrestview(preserve_cursor.state.win_state)
 
-    preserve_cursor.state = {
-      cusor_position = nil,
-      win_state = nil,
-    }
+      preserve_cursor.state = {
+        cusor_position = nil,
+        win_state = nil,
+      }
+    end, preserve_cursor.config.timer or 0)
   end
 end
 


### PR DESCRIPTION
This commit introduces an optional parameter, 'timer', to the 'preserve_cursor_position' feature.
The inclusion of this parameter helps prevent a potentially jarring cursor jump after a lengthy multiline yank operation with a downwards motion.