### PR TITLE
feat: config option for system clipboard register

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Yanky comes with the following defaults:
   },
   system_clipboard = {
     sync_with_ring = true,
+    clipboard_register = nil,
   },
   highlight = {
     on_put = true,
@@ -279,6 +280,17 @@ added to your yank ring.
 If `&clipboard` is empty, if you yank something outside of Neovim, this will be
 the first value you'll have when cycling through the ring. Basicly, you can do
 `p` and then `<c-p>` to paste yanked text.
+
+Note that `clipboard == unnamed` uses the primary selection of the system (see
+`:h clipbard` for more details) which is updated on selection, not on copy/yank.
+Also note that the syncing happens when neovim gains focus.
+
+### `system_clipboard.clipboard_register`
+
+Default: `nil` use `&clipboard`
+
+Choose the register that is synced with ring (from above). If `&clipboard` is
+empty then `*` is used.
 
 ### `ring.update_register_on_cycle`
 

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -14,6 +14,7 @@ local default_values = {
   },
   system_clipboard = {
     sync_with_ring = true,
+    clipboard_register = nil,
   },
   highlight = {
     on_put = true,

--- a/lua/yanky/system_clipboard.lua
+++ b/lua/yanky/system_clipboard.lua
@@ -8,6 +8,7 @@ local system_clipboard = {
 
 function system_clipboard.setup()
   system_clipboard.config = require("yanky.config").options.system_clipboard
+  system_clipboard.config.clipboard_register = system_clipboard.config.clipboard_register or utils.get_system_register()
   system_clipboard.history = require("yanky.history")
 
   if system_clipboard.config.sync_with_ring then
@@ -44,11 +45,11 @@ function system_clipboard.setup()
 end
 
 function system_clipboard.on_focus_lost()
-  system_clipboard.state.reg_info_on_focus_lost = utils.get_register_info(utils.get_system_register())
+  system_clipboard.state.reg_info_on_focus_lost = utils.get_register_info(system_clipboard.config.clipboard_register)
 end
 
 function system_clipboard.on_focus_gained()
-  local new_reg_info = utils.get_register_info(utils.get_system_register())
+  local new_reg_info = utils.get_register_info(system_clipboard.config.clipboard_register)
 
   if
     system_clipboard.state.reg_info_on_focus_lost ~= nil

--- a/lua/yanky/utils.lua
+++ b/lua/yanky/utils.lua
@@ -25,7 +25,6 @@ function utils.get_system_register()
   if vim.tbl_contains(clipboardFlags, "unnamedplus") then
     return "+"
   end
-
   return "*"
 end
 


### PR DESCRIPTION
if `opt.clipboard == ""` (because we want yanky to sync with system but
    not in the primary position) then the `*` register is used, with no
    way to choose `+`. So simply we add the necessary config option.
