### PR TITLE
fix: prevent focus lost/gained loop on linux/wayland. Fixes #182

### DIFF
--- a/lua/yanky/utils.lua
+++ b/lua/yanky/utils.lua
@@ -1,4 +1,5 @@
 local utils = {}
+utils.fetching = false
 
 function utils.get_default_register()
   local clipboard_tool = vim.fn["provider#clipboard#Executable"]()
@@ -29,6 +30,10 @@ function utils.get_system_register()
 end
 
 function utils.get_register_info(register)
+  utils.fetching = true
+  vim.schedule(function()
+    utils.fetching = false
+  end)
   return {
     regcontents = vim.fn.getreg(register),
     regtype = vim.fn.getregtype(register),


### PR DESCRIPTION
The same logic that was initially only applied on focus gained, now also needs to be applied on focus lost.

https://github.com/LazyVim/LazyVim/issues/3321

Fixes #182 