### PR TITLE
 docs: update `substitute.nvim` integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ require("substitute").setup({
 or
 ```lua
 opts = {
-  on_substitute = function() require('yanky.integration').substitute() end,
+  on_substitute = function() require("yanky.integration").substitute() end,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -706,6 +706,12 @@ require("substitute").setup({
   on_substitute = require("yanky.integration").substitute(),
 })
 ```
+or
+```lua
+opts = {
+  on_substitute = function() require('yanky.integration').substitute() end,
+}
+```
 
 </details>
 


### PR DESCRIPTION
When user does not call `setup`, the option `on_substitute` should be wrapped as a function.