### PR TITLE
remove `\r` when pasting if wsl is set.

### DIFF
--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -4,6 +4,7 @@ local system_clipboard = require("yanky.system_clipboard")
 local preserve_cursor = require("yanky.preserve_cursor")
 local picker = require("yanky.picker")
 local textobj = require("yanky.textobj")
+local config  = require("yanky.config")
 
 local yanky = {}
 
@@ -69,8 +70,11 @@ local function do_put(state, _)
   if state.is_visual then
     vim.cmd([[execute "normal! \<esc>"]])
   end
-  local regcontents = vim.fn.getreg(state.register)
-  vim.fn.setreg(state.register, string.gsub(regcontents, "\r", ""))
+  local regcontents = nil
+  if config.options.wsl then
+    regcontents = vim.fn.getreg(state.register)
+    vim.fn.setreg(state.register, string.gsub(regcontents, "\r", ""))
+  end
   local ok, val = pcall(
     vim.cmd,
     string.format(
@@ -81,7 +85,9 @@ local function do_put(state, _)
       state.type
     )
   )
-  vim.fn.setreg(state.register, regcontents)
+  if config.options.wsl then
+    vim.fn.setreg(state.register, regcontents)
+  end
   if not ok then
     vim.notify(val, vim.log.levels.WARN)
     return

--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -162,7 +162,7 @@ function yanky.init_ring(type, register, count, is_visual, callback)
 
   if config.options.wsl then
     reg_content = vim.fn.getreg(register)
-    vim.fn.setreg(register, string.gsub(reg_content, "\r", "-------------"), reg_type)
+    vim.fn.setreg(register, string.gsub(reg_content, "\r", ""), reg_type)
   end
   if nil ~= callback then
     callback(new_state, do_put)

--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -70,6 +70,7 @@ local function do_put(state, _)
   if state.is_visual then
     vim.cmd([[execute "normal! \<esc>"]])
   end
+
   local ok, val = pcall(
     vim.cmd,
     string.format(
@@ -106,10 +107,8 @@ function yanky.put(type, is_visual, callback)
 
     yanky.history.push(entry)
   end
-  local regcontents = nil
 
   yanky.init_ring(type, vim.v.register, vim.v.count, is_visual, yanky.ring.callback)
-
 end
 
 function yanky.clear_ring()

--- a/lua/yanky.lua
+++ b/lua/yanky.lua
@@ -69,7 +69,8 @@ local function do_put(state, _)
   if state.is_visual then
     vim.cmd([[execute "normal! \<esc>"]])
   end
-
+  local regcontents = vim.fn.getreg(state.register)
+  vim.fn.setreg(state.register, string.gsub(regcontents, "\r", ""))
   local ok, val = pcall(
     vim.cmd,
     string.format(
@@ -80,6 +81,7 @@ local function do_put(state, _)
       state.type
     )
   )
+  vim.fn.setreg(state.register, regcontents)
   if not ok then
     vim.notify(val, vim.log.levels.WARN)
     return

--- a/lua/yanky/config.lua
+++ b/lua/yanky/config.lua
@@ -1,6 +1,8 @@
 local config = {}
 
-config.options = {}
+config.options = {
+  wsl = false,
+}
 
 local default_values = {
   ring = {


### PR DESCRIPTION
In wsl, when pasting from system clipboard, there's a `^M` at the end of each line.  An option `wsl` is added, and when it is set true, `^M` will be removed when pasting.