### PR TITLE
perf: speed up default register determination

### DIFF
--- a/lua/yanky/utils.lua
+++ b/lua/yanky/utils.lua
@@ -1,28 +1,31 @@
 local utils = {}
 
 function utils.get_default_register()
-  local clipboard_tool = vim.fn["provider#clipboard#Executable"]()
-  if not clipboard_tool or "" == clipboard_tool then
-    return '"'
-  end
-
-  local clipboard_flags = vim.split(vim.api.nvim_get_option("clipboard"), ",")
+  local clipboard_flags = vim.split(vim.api.nvim_get_option_value("clipboard", {}), ",")
+  local selected_register = '"'
 
   if vim.tbl_contains(clipboard_flags, "unnamedplus") then
-    return "+"
+    selected_register = "+"
   end
 
   if vim.tbl_contains(clipboard_flags, "unnamed") then
-    return "*"
+    selected_register = "*"
   end
 
-  return '"'
+  if selected_register ~= '"' then
+    local clipboard_tool = vim.fn["provider#clipboard#Executable"]()
+    if not clipboard_tool or "" == clipboard_tool then
+      return '"'
+    end
+  end
+
+  return selected_register
 end
 
 function utils.get_system_register()
-  local clipboardFlags = vim.split(vim.api.nvim_get_option("clipboard"), ",")
+  local clipboard_flags = vim.split(vim.api.nvim_get_option_value("clipboard", {}), ",")
 
-  if vim.tbl_contains(clipboardFlags, "unnamedplus") then
+  if vim.tbl_contains(clipboard_flags, "unnamedplus") then
     return "+"
   end
   return "*"


### PR DESCRIPTION
`provider#clipboard#Executable` can be very slow on remote machines (the following profile shows an execution time of 5 seconds).

![image](https://github.com/user-attachments/assets/3f0eb917-c1ae-46ba-ae92-48e0e4885694)

I swapped the order in `utils.get_default_register`, eliminating unnecessary calls to `provider#clipboard#Executable` when the `clipboard` option is unset. This change significantly reduces both put latency and startup time.