### PR TITLE
fix: make regcontents searchable in yanky picker

### DIFF
--- a/lua/yanky/sources/snacks.lua
+++ b/lua/yanky/sources/snacks.lua
@@ -22,6 +22,7 @@ M.config = {
     local items = {}
     for index, value in pairs(require("yanky.history").all()) do
       value.key = index
+      value.text = tostring(value.regcontents)
       items[#items + 1] = value
     end
     return items


### PR DESCRIPTION
This allows searching the yank history listing. Typing into the search box before would return the following error:

```
Unhandled async error:
...nvim/lazy/snacks.nvim/lua/snacks/picker/core/matcher.lua:484: attempt to index local 'str' (a nil value)
```