### PR TITLE
fix: gracefully handle clipboard provider errors

### DIFF
--- a/lua/yanky/system_clipboard.lua
+++ b/lua/yanky/system_clipboard.lua
@@ -51,6 +51,11 @@ end
 function system_clipboard.on_focus_gained()
   local new_reg_info = utils.get_register_info(system_clipboard.config.clipboard_register)
 
+  if new_reg_info == nil then
+    system_clipboard.state.reg_info_on_focus_lost = nil
+    return
+  end
+
   if
     system_clipboard.state.reg_info_on_focus_lost ~= nil
     and not vim.deep_equal(system_clipboard.state.reg_info_on_focus_lost, new_reg_info)

--- a/lua/yanky/utils.lua
+++ b/lua/yanky/utils.lua
@@ -32,9 +32,16 @@ function utils.get_system_register()
 end
 
 function utils.get_register_info(register)
+  local ok_contents, regcontents = pcall(vim.fn.getreg, register)
+  local ok_type, regtype = pcall(vim.fn.getregtype, register)
+
+  if not ok_contents or not ok_type then
+    return nil
+  end
+
   return {
-    regcontents = vim.fn.getreg(register),
-    regtype = vim.fn.getregtype(register),
+    regcontents = regcontents,
+    regtype = regtype,
   }
 end
 


### PR DESCRIPTION
Wrap vim.fn.getreg and vim.fn.getregtype in pcall to prevent errors
when the clipboard provider returns invalid data (e.g., headless Neovim
with Neovide on WSL).

Fixes #227