### PR TITLE
fix: use `vim.hl.hl_op` if available

### DIFF
--- a/lua/yanky/highlight.lua
+++ b/lua/yanky/highlight.lua
@@ -3,6 +3,14 @@ local highlight = {}
 -- Use the non-deprecated `vim.hl` if available.
 vim.hl = vim.hl or vim.highlight
 
+local function hl_op(opts)
+  if vim.hl.hl_op then
+    return vim.hl.hl_op(opts)
+  end
+
+  return vim.hl.on_yank(opts)
+end
+
 function highlight.setup()
   highlight.config = require("yanky.config").options.highlight
   if highlight.config.on_put then
@@ -16,7 +24,7 @@ function highlight.setup()
     vim.api.nvim_create_autocmd("TextYankPost", {
       pattern = "*",
       callback = function(_)
-        pcall(vim.hl.on_yank, { higroup = "YankyYanked", timeout = highlight.config.timer })
+        pcall(hl_op, { higroup = "YankyYanked", timeout = highlight.config.timer })
       end,
     })
 


### PR DESCRIPTION
Updating yank highlighting to prefer the non-deprecated `vim.hl.hl_op()` API when available, avoiding the `vim.hl.on_yank` deprecation warning on newer Neovim versions (see https://github.com/neovim/neovim/pull/39777)

Keeping compatibility with older Neovim releases by falling back to `vim.hl.on_yank()` when `hl_op` is not present.