### PR TITLE
fix: skip history push when register info is nil

### DIFF
--- a/lua/yanky/history.lua
+++ b/lua/yanky/history.lua
@@ -13,6 +13,12 @@ function history.setup()
 end
 
 function history.push(item)
+  if item == nil then
+    -- `utils.get_register_info` returns nil when the register can't be read
+    -- (e.g. a clipboard provider error), so there is nothing to push.
+    return
+  end
+
   local prev = history.storage.get(1)
   if prev ~= nil and prev.regcontents == item.regcontents and prev.regtype == item.regtype then
     return


### PR DESCRIPTION
`utils.get_register_info` returns nil when the register can't be read (the `pcall` added in #235), so `init_history` can end up calling `history.push(nil)`. When there's existing history, `prev.regcontents == item.regcontents` then indexes the nil item and errors with `attempt to index local 'item'`.

Skip the push when the item is nil — if there's no register info there's nothing to store.

Fixes #243