### PR TITLE
Fix typo in vimdoc header (2)

### DIFF
--- a/.github/workflows/panvimdoc.yml
+++ b/.github/workflows/panvimdoc.yml
@@ -14,7 +14,7 @@ jobs:
         uses: kdheepak/panvimdoc@main
         with:
           vimdoc: yanky
-          description: Improved Yank an Put functionalities for Neovim
+          description: Improved Yank and Put functionalities for Neovim
           version: 'NVIM v0.6.0'
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION

Howdy (again)! Just noticed that the most recent [commit](https://github.com/gbprod/yanky.nvim/commit/020c22d0cfa6) undid my tipo fixamundo since the docs are autogenerated w/ panvimdoc, so I edited the corresponding config file accordingly to put the final nail in the coffin. Much love, hopefully one day I'll actually be productive with these splendid tools instead of just fixing gay grammar shit lol.
